### PR TITLE
addr.extendedの返却値がundefinedだった場合に住所欄にundefinedが入らないように修正

### DIFF
--- a/ajaxzip3.ts
+++ b/ajaxzip3.ts
@@ -25,6 +25,7 @@ module YubinBango {
       }
     }
     apply(elms, addr){
+      if(!addr.extended) { addr.extended = '' }
       let cursor = elms['locality'];
       if (elms['region'].type == 'select-one' || elms['region'].type == 'select-multiple') {
         // 都道府県プルダウンの場合


### PR DESCRIPTION
Coreから取得するアドレスオブジェクトのextendedにundefinedが入った場合、住所の文字列にもundefinedが入ってしまうため、入らないように修正しました
